### PR TITLE
Set up initial Flutter app with theme and routing

### DIFF
--- a/lib/app_theme.dart
+++ b/lib/app_theme.dart
@@ -1,0 +1,30 @@
+import 'package:flutter/material.dart';
+
+class AppColors {
+  static const background = Color(0xFF12211F);
+  static const primary = Color(0xFF149E85);
+  static const base = Color(0xFF264540);
+  static const text = Color(0xFFFFFFFF);
+}
+
+class AppTheme {
+  static ThemeData get theme {
+    return ThemeData(
+      useMaterial3: true,
+      scaffoldBackgroundColor: AppColors.background,
+      fontFamily: 'Pretendard',
+      colorScheme: ColorScheme.fromSeed(
+        seedColor: AppColors.primary,
+        background: AppColors.background,
+        primary: AppColors.primary,
+        secondary: AppColors.base,
+        brightness: Brightness.dark,
+      ),
+      textTheme: Typography.whiteMountainView.apply(
+        bodyColor: AppColors.text,
+        displayColor: AppColors.text,
+      ),
+    );
+  }
+}
+

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,0 +1,28 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import 'app_theme.dart';
+import 'router.dart';
+
+Future<void> main() async {
+  WidgetsFlutterBinding.ensureInitialized();
+
+  runApp(
+    const ProviderScope(
+      child: MyApp(),
+    ),
+  );
+}
+
+class MyApp extends StatelessWidget {
+  const MyApp({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp.router(
+      theme: AppTheme.theme,
+      routerConfig: router,
+    );
+  }
+}
+

--- a/lib/router.dart
+++ b/lib/router.dart
@@ -1,0 +1,12 @@
+import 'package:go_router/go_router.dart';
+import 'screens/intro_screen.dart';
+
+final router = GoRouter(
+  routes: [
+    GoRoute(
+      path: '/',
+      builder: (context, state) => const IntroScreen(),
+    ),
+  ],
+);
+

--- a/lib/screens/intro_screen.dart
+++ b/lib/screens/intro_screen.dart
@@ -1,0 +1,19 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+class IntroScreen extends ConsumerWidget {
+  const IntroScreen({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Intro'),
+      ),
+      body: const Center(
+        child: Text('Intro Screen'),
+      ),
+    );
+  }
+}
+


### PR DESCRIPTION
## Summary
- bootstrap Flutter project with main.dart
- define color and font constants in `app_theme.dart`
- implement an intro screen as a ConsumerWidget
- configure GoRouter and apply ProviderScope

## Testing
- `flutter --version` *(fails: command not found)*
- `apt-get update` *(fails: internet is disabled)*

------
https://chatgpt.com/codex/tasks/task_e_6878fd7af88c832ba469199830f7d292