### PR TITLE
Add animated Intro screen

### DIFF
--- a/lib/screens/intro_screen.dart
+++ b/lib/screens/intro_screen.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
@@ -6,14 +8,76 @@ class IntroScreen extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
+    final colors = Theme.of(context).colorScheme;
     return Scaffold(
-      appBar: AppBar(
-        title: const Text('Intro'),
-      ),
-      body: const Center(
-        child: Text('Intro Screen'),
+      backgroundColor: colors.background,
+      body: Column(
+        children: [
+          Expanded(
+            child: Center(
+              child: Image.asset(
+                'assets/img/large_logo.png',
+                fit: BoxFit.contain,
+                width: MediaQuery.of(context).size.width * 0.8,
+                height: MediaQuery.of(context).size.height * 0.3,
+              ),
+            ),
+          ),
+          const LoadingDots(),
+        ],
       ),
     );
   }
 }
 
+class LoadingDots extends ConsumerStatefulWidget {
+  const LoadingDots({super.key});
+
+  @override
+  ConsumerState<LoadingDots> createState() => _LoadingDotsState();
+}
+
+class _LoadingDotsState extends ConsumerState<LoadingDots> {
+  int _activeIndex = 0;
+  late Timer _timer;
+
+  @override
+  void initState() {
+    super.initState();
+    _timer = Timer.periodic(const Duration(milliseconds: 400), (_) {
+      setState(() => _activeIndex = (_activeIndex + 1) % 3);
+    });
+  }
+
+  @override
+  void dispose() {
+    _timer.cancel();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = Theme.of(context).colorScheme;
+    return Padding(
+      padding: const EdgeInsets.only(bottom: 32.0),
+      child: Row(
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: List.generate(3, (index) {
+          final color = index == _activeIndex ? colors.primary : colors.secondary;
+          return Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 4.0),
+            child: AnimatedContainer(
+              duration: const Duration(milliseconds: 300),
+              width: 10,
+              height: 10,
+              decoration: BoxDecoration(
+                shape: BoxShape.circle,
+                color: color,
+              ),
+            ),
+          );
+        }),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- replace Intro screen with animated splash-style screen
- use theme colors
- update loading dots to use ConsumerStatefulWidget

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687906669e34832b84803909ac5a47e5