### PR TITLE
Add device setup screen and auto intro navigation

### DIFF
--- a/lib/router.dart
+++ b/lib/router.dart
@@ -1,11 +1,16 @@
 import 'package:go_router/go_router.dart';
 import 'screens/intro_screen.dart';
+import 'screens/add_devices_screen.dart';
 
 final router = GoRouter(
   routes: [
     GoRoute(
       path: '/',
       builder: (context, state) => const IntroScreen(),
+    ),
+    GoRoute(
+      path: '/add-devices',
+      builder: (context, state) => const AddDevicesScreen(),
     ),
   ],
 );

--- a/lib/screens/add_devices_screen.dart
+++ b/lib/screens/add_devices_screen.dart
@@ -1,0 +1,116 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+class AddDevicesScreen extends ConsumerWidget {
+  const AddDevicesScreen({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final colors = Theme.of(context).colorScheme;
+    return Scaffold(
+      backgroundColor: colors.background,
+      appBar: AppBar(
+        backgroundColor: colors.background,
+        leading: IconButton(
+          icon: Icon(Icons.arrow_back, color: colors.onBackground),
+          onPressed: () {
+            Navigator.of(context).maybePop();
+          },
+        ),
+        title: Text(
+          'Add Devices',
+          style: TextStyle(color: colors.onBackground),
+        ),
+        elevation: 0,
+      ),
+      body: SafeArea(
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            Expanded(
+              flex: 3,
+              child: Center(
+                child: Padding(
+                  padding: const EdgeInsets.all(16.0),
+                  child: Image.asset(
+                    'assets/robotic_hand.png',
+                    fit: BoxFit.contain,
+                    width: MediaQuery.of(context).size.width * 0.6,
+                  ),
+                ),
+              ),
+            ),
+            Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 16.0, vertical: 8.0),
+              child: Text(
+                '로봇의 전원을 켜고 근처에 있는지 확인하세요.',
+                style: TextStyle(color: colors.onBackground, fontSize: 16),
+                textAlign: TextAlign.center,
+              ),
+            ),
+            Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 16.0, vertical: 8.0),
+              child: ElevatedButton(
+                onPressed: () {},
+                style: ElevatedButton.styleFrom(
+                  backgroundColor: colors.primary,
+                  shape: RoundedRectangleBorder(
+                    borderRadius: BorderRadius.circular(30),
+                  ),
+                  minimumSize: const Size(double.infinity, 50),
+                ),
+                child: Text(
+                  'QR코드 스캔하기',
+                  style: TextStyle(color: colors.onPrimary, fontSize: 16),
+                ),
+              ),
+            ),
+            Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 16.0, vertical: 4.0),
+              child: ElevatedButton(
+                onPressed: () {},
+                style: ElevatedButton.styleFrom(
+                  backgroundColor: colors.secondary,
+                  shape: RoundedRectangleBorder(
+                    borderRadius: BorderRadius.circular(30),
+                  ),
+                  minimumSize: const Size(double.infinity, 50),
+                ),
+                child: Text(
+                  '블루투스 추가하기',
+                  style: TextStyle(color: colors.onSecondary, fontSize: 16),
+                ),
+              ),
+            ),
+            Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 16.0, vertical: 4.0),
+              child: ElevatedButton(
+                onPressed: () {},
+                style: ElevatedButton.styleFrom(
+                  backgroundColor: colors.secondary,
+                  shape: RoundedRectangleBorder(
+                    borderRadius: BorderRadius.circular(30),
+                  ),
+                  minimumSize: const Size(double.infinity, 50),
+                ),
+                child: Text(
+                  '수동으로 추가하기',
+                  style: TextStyle(color: colors.onSecondary, fontSize: 16),
+                ),
+              ),
+            ),
+            const Spacer(),
+            Padding(
+              padding: const EdgeInsets.only(bottom: 16.0),
+              child: Text(
+                '로봇 키트 구매 후 이용이 가능합니다.',
+                style: TextStyle(color: Colors.white70, fontSize: 14),
+                textAlign: TextAlign.center,
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/screens/intro_screen.dart
+++ b/lib/screens/intro_screen.dart
@@ -2,12 +2,36 @@ import 'dart:async';
 
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
 
-class IntroScreen extends ConsumerWidget {
+class IntroScreen extends ConsumerStatefulWidget {
   const IntroScreen({super.key});
 
   @override
-  Widget build(BuildContext context, WidgetRef ref) {
+  ConsumerState<IntroScreen> createState() => _IntroScreenState();
+}
+
+class _IntroScreenState extends ConsumerState<IntroScreen> {
+  Timer? _timer;
+
+  @override
+  void initState() {
+    super.initState();
+    _timer = Timer(const Duration(seconds: 5), () {
+      if (mounted) {
+        context.go('/add-devices');
+      }
+    });
+  }
+
+  @override
+  void dispose() {
+    _timer?.cancel();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
     final colors = Theme.of(context).colorScheme;
     return Scaffold(
       backgroundColor: colors.background,


### PR DESCRIPTION
## Summary
- add AddDevicesScreen with themed colors
- navigate to AddDevicesScreen after 5 seconds on IntroScreen
- register new screen in GoRouter

## Testing
- `which flutter` *(fails: no output)*

------
https://chatgpt.com/codex/tasks/task_e_68790f7ac0b4832bbed080f029a751c3